### PR TITLE
services > add support for Generic SQL using database/sql

### DIFF
--- a/.buildkite/pipeline-tests.yml
+++ b/.buildkite/pipeline-tests.yml
@@ -70,3 +70,10 @@ steps:
       - "docker=true"
       - "os=linux"
       - "type=lite"
+
+  - command: "make -f Makefile.ci test_services_sql_dkr"
+    label: "services/sql pkg"
+    agents:
+      - "docker=true"
+      - "os=linux"
+      - "type=lite"

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ before_install:
     - make -f Makefile.ci tools_external
 install:
     - make -f Makefile deps
-    - docker-compose -f docker-compose.yml up -d nats kafka es1 es2 es5
+    - docker-compose -f docker-compose.yml up -d nats kafka es1 es2 es5 sql
 script:
     - make -f Makefile.ci tests
     - make -f Makefile.ci coverage

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -200,3 +200,9 @@
   inputs-digest = "c0e08ec5e9597b642de46749c9fb1bdc137596980dcb143b4bb75fd62fc2a1b4"
   solver-name = "gps-cdcl"
   solver-version = 1
+
+  [[projects]]
+  branch = "master"
+  name = "github.com/lib/pq"
+  packages = ["."]
+  revision = "88edab0803230a3898347e77b474f8c1820a1f20"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -72,3 +72,7 @@
 [[constraint]]
   name = "gopkg.in/olivere/elastic.v5"
   version = "5.*"
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/lib/pq"

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -77,9 +77,15 @@ test_services_nats:
 test_services_nats_dkr: pull_dkr
 	docker run -e $(ENV_DKR_NATS) $(DKR_IMG_PATH) go test -v -race -cpu 1,4 -run=. -bench=. ./services/nats
 
-tests: test_root test_services_cql test_services_es1 test_services_es2 test_services_es5 test_services_redis test_services_memcached test_services_nats
+test_services_sql:
+	go test -v -race -cpu 1,4 -run=. -bench=. -covermode=atomic -coverprofile=coverage9.out ./services/sql
 
-tests_dkr: test_root_dkr test_services_cql_dkr test_services_es1_dkr test_services_es2_dkr test_services_es5_dkr test_services_redis_dkr test_services_memcached_dkr test_services_nats_dkr
+test_services_sql_dkr: pull_dkr
+	docker run -e $(ENV_DKR_SQL) $(DKR_IMG_PATH) go test -v -race -cpu 1,4 -run=. -bench=. ./services/sql
+
+tests: test_root test_services_cql test_services_es1 test_services_es2 test_services_es5 test_services_redis test_services_memcached test_services_nats test_services_sql
+
+tests_dkr: test_root_dkr test_services_cql_dkr test_services_es1_dkr test_services_es2_dkr test_services_es5_dkr test_services_redis_dkr test_services_memcached_dkr test_services_nats_dkr test_services_sql_dkr
 
 coverage:
 	bash coverage.sh

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ It provides a fully tested & thread-safe package that implements some of the mos
 - ElasticSearch-v1 via [gopkg.in/olivere/elastic.v2](https://gopkg.in/olivere/elastic.v2)
 - ElasticSearch-v2 via [gopkg.in/olivere/elastic.v3](https://gopkg.in/olivere/elastic.v3)
 - ElasticSearch-v5 via [gopkg.in/olivere/elastic.v5](https://gopkg.in/olivere/elastic.v5)
+- Generic SQL via [golang.org/pkg/database/sql](https://golang.org/pkg/database/sql/)
 
 Any of these services would be configured and instanciated the exact same way:
 ```Go
@@ -39,6 +40,7 @@ Any of these services would be configured and instanciated the exact same way:
 	es1Env, _ := bm_es1.NewEnv("ES1_EXAMPLE")
 	es2Env, _ := bm_es2.NewEnv("ES2_EXAMPLE")
 	es5Env, _ := bm_es5.NewEnv("ES5_EXAMPLE")
+	sqlEnv, _ := bm_sql.NewEnv("SQL_EXAMPLE")
 
 	m.AddService("mc-1", true, bm_memcached.New(memcachedEnv.Config()))
 	m.AddService("rd-1", true, bm_redis.New(redisEnv.Config()))
@@ -48,6 +50,7 @@ Any of these services would be configured and instanciated the exact same way:
 	m.AddService("es1-1", true, bm_es1.New(es1Env.Config()))
 	m.AddService("es2-1", true, bm_es2.New(es2Env.Config()))
 	m.AddService("es5-1", true, bm_es5.New(es5Env.Config()))
+	m.AddService("sql-1", true, bm_sql.New(sqlEnv.Config()))
 ```
 
 In addition to these standard implementations, *BandMaster* provides a straightforward API so that you can easily implement your own services; see [this section](#implementing-a-custom-service) for more details.
@@ -229,7 +232,7 @@ Also, do not hesitate to open an issue if some piece of documentation looks eith
 ### Running tests
 
 ```
-$ docker-compose -f test/docker-compose.yml up -d
+$ docker-compose -f docker-compose.yml up -d
 $ make test
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,3 +52,11 @@ services:
         ports:
             - "9205:9200"
         restart: on-failure
+
+    sql:
+        image: postgres
+        environment:
+            POSTGRES_PASSWORD: postgres
+        ports:
+            - "5432:5432"
+        restart: on-failure

--- a/services/sql/env.go
+++ b/services/sql/env.go
@@ -26,9 +26,9 @@ import (
 // Env can be used to configure a SQL session via the environment.
 //
 // It comes with sane defaults for a local development set-up.
-// The default driver is setup to Postgres with a working local Addr
+// The default driver is setup to `posgres` with a working local address.
 type Env struct {
-	DriverName      string        `envconfig:"DRIVER_NAME" default:"postgres"`
+	Driver          string        `envconfig:"DRIVER" default:"postgres"`
 	Addr            string        `envconfig:"ADDR" default:"postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"`
 	ConnMaxLifetime time.Duration `envconfig:"CONN_MAX_LIFETIME" default:"10m"`
 	MaxIdleConns    int           `envconfig:"MAX_IDLE_CONNS" default:"1"`
@@ -50,7 +50,7 @@ func NewEnv(prefix string) (*Env, error) {
 // Config returns a `Config` using the values from the environment.
 func (e *Env) Config() *Config {
 	var config Config
-	config.DriverName = e.DriverName
+	config.Driver = e.Driver
 	config.Addr = e.Addr
 	config.ConnMaxLifetime = e.ConnMaxLifetime
 	config.MaxIdleConns = e.MaxIdleConns

--- a/services/sql/env.go
+++ b/services/sql/env.go
@@ -1,0 +1,59 @@
+// Copyright © 2017 Zenly <hello@zen.ly>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"time"
+
+	"github.com/kelseyhightower/envconfig"
+	"github.com/pkg/errors"
+)
+
+// -----------------------------------------------------------------------------
+
+// Env can be used to configure a SQL session via the environment.
+//
+// It comes with sane defaults for a local development set-up.
+// The default driver is setup to Postgres with a working local Addr
+type Env struct {
+	DriverName      string        `envconfig:"DRIVER_NAME" default:"postgres"`
+	Addr            string        `envconfig:"ADDR" default:"postgres://postgres:postgres@127.0.0.1:5432/postgres?sslmode=disable"`
+	ConnMaxLifetime time.Duration `envconfig:"CONN_MAX_LIFETIME" default:"10m"`
+	MaxIdleConns    int           `envconfig:"MAX_IDLE_CONNS" default:"1"`
+	MaxOpenConns    int           `envconfig:"MAX_OPEN_CONNS" default:"2"`
+}
+
+// NewEnv parses the environment and returns a new `Env` structure.
+//
+// `prefix` defines the prefix for the environment keys, e.g. with a 'XX' prefix,
+// 'REPLICAS' would become 'XX_REPLICAS'.
+func NewEnv(prefix string) (*Env, error) {
+	e := &Env{}
+	if err := envconfig.Process(prefix, e); err != nil {
+		return nil, errors.WithStack(err)
+	}
+	return e, nil
+}
+
+// Config returns a `Config` using the values from the environment.
+func (e *Env) Config() *Config {
+	var config Config
+	config.DriverName = e.DriverName
+	config.Addr = e.Addr
+	config.ConnMaxLifetime = e.ConnMaxLifetime
+	config.MaxIdleConns = e.MaxIdleConns
+	config.MaxOpenConns = e.MaxOpenConns
+	return &config
+}

--- a/services/sql/service.go
+++ b/services/sql/service.go
@@ -16,7 +16,7 @@ type Service struct {
 }
 
 type Config struct {
-	DriverName      string
+	Driver          string
 	Addr            string
 	ConnMaxLifetime time.Duration
 	MaxIdleConns    int
@@ -39,16 +39,15 @@ func New(conf *Config) bandmaster.Service {
 
 // -----------------------------------------------------------------------------
 
-// Start opens PING the server and establish a connection if necessary:
-// the service is marked as 'started' in case of success;
-// otherwise, an error is returned.
+// Start opens a connection and PINGs the server: if everything goes smoothly,
+// the service is marked as 'started'; otherwise, an error is returned.
 //
 //
 // Start is used by BandMaster's internal machinery, it shouldn't ever be called
 // directly by the end-user of the service.
 func (s *Service) Start(context.Context, map[string]bandmaster.Service) error {
 	var err error
-	s.db, err = sql.Open(s.config.DriverName, s.config.Addr)
+	s.db, err = sql.Open(s.config.Driver, s.config.Addr)
 	if err != nil {
 		return err
 	}
@@ -67,9 +66,7 @@ func (s *Service) Start(context.Context, map[string]bandmaster.Service) error {
 //
 // Stop is used by BandMaster's internal machinery, it shouldn't ever be called
 // directly by the end-user of the service.
-func (s *Service) Stop(context.Context) error {
-	return s.db.Close()
-}
+func (s *Service) Stop(context.Context) error { return s.db.Close() }
 
 // -----------------------------------------------------------------------------
 
@@ -78,7 +75,7 @@ func (s *Service) Stop(context.Context) error {
 // It assumes that the service is ready; i.e. it might return nil if it's
 // actually not.
 //
-// NOTE: This will panic if `s` is not a `sql.DB`.
+// NOTE: This will panic if `s` is not a `sql.Service`.
 func Client(s bandmaster.Service) *sql.DB {
 	return s.(*Service).db
 }

--- a/services/sql/service.go
+++ b/services/sql/service.go
@@ -1,0 +1,84 @@
+package sql
+
+import (
+	"context"
+	"database/sql"
+	"time"
+
+	"github.com/znly/bandmaster"
+)
+
+type Service struct {
+	*bandmaster.ServiceBase // "inheritance"
+
+	config *Config
+	db     *sql.DB
+}
+
+type Config struct {
+	DriverName      string
+	Addr            string
+	ConnMaxLifetime time.Duration
+	MaxIdleConns    int
+	MaxOpenConns    int
+}
+
+// New creates a new SQL service using the provided `Config`.
+// You may use the helpers for environment-based configuration to get a
+// pre-configured `Config` with sane defaults.
+//
+// It doesn't open any connection nor does it do any kind of I/O; i.e. it
+// cannot fail.
+func New(conf *Config) bandmaster.Service {
+	return &Service{
+		ServiceBase: bandmaster.NewServiceBase(), // "inheritance"
+		config:      conf,
+		db:          nil,
+	}
+}
+
+// -----------------------------------------------------------------------------
+
+// Start opens PING the server and establish a connection if necessary:
+// the service is marked as 'started' in case of success;
+// otherwise, an error is returned.
+//
+//
+// Start is used by BandMaster's internal machinery, it shouldn't ever be called
+// directly by the end-user of the service.
+func (s *Service) Start(context.Context, map[string]bandmaster.Service) error {
+	var err error
+	s.db, err = sql.Open(s.config.DriverName, s.config.Addr)
+	if err != nil {
+		return err
+	}
+	s.db.SetConnMaxLifetime(s.config.ConnMaxLifetime)
+	s.db.SetMaxIdleConns(s.config.MaxIdleConns)
+	s.db.SetMaxOpenConns(s.config.MaxOpenConns)
+
+	if err := s.db.Ping(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Stop closes the database, releasing any open resources.
+//
+//
+// Stop is used by BandMaster's internal machinery, it shouldn't ever be called
+// directly by the end-user of the service.
+func (s *Service) Stop(context.Context) error {
+	return s.db.Close()
+}
+
+// -----------------------------------------------------------------------------
+
+// Client returns the underlying `sql.DB` of the given service.
+//
+// It assumes that the service is ready; i.e. it might return nil if it's
+// actually not.
+//
+// NOTE: This will panic if `s` is not a `sql.DB`.
+func Client(s bandmaster.Service) *sql.DB {
+	return s.(*Service).db
+}

--- a/services/sql/service_test.go
+++ b/services/sql/service_test.go
@@ -1,0 +1,42 @@
+// Copyright © 2017 Zenly <hello@zen.ly>.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sql
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/znly/bandmaster"
+	"github.com/znly/bandmaster/services"
+
+	_ "github.com/lib/pq"
+)
+
+// -----------------------------------------------------------------------------
+
+// Tests are run with the Default env config: PostgreSQL using lib/pq
+func TestService_SQL(t *testing.T) {
+	env, _ := NewEnv("BM_SQL")
+	assert.NotNil(t, env)
+	conf := env.Config()
+	assert.NotNil(t, conf)
+
+	services.TestService_Generic(t, New(conf),
+		func(t *testing.T, s bandmaster.Service) {
+			c := Client(s)
+			assert.NotNil(t, c)
+		},
+	)
+}

--- a/services/sql/service_test.go
+++ b/services/sql/service_test.go
@@ -26,7 +26,7 @@ import (
 
 // -----------------------------------------------------------------------------
 
-// Tests are run with the Default env config: PostgreSQL using lib/pq
+// Tests are run with the Default env config: PostgreSQL using lib/pq.
 func TestService_SQL(t *testing.T) {
 	env, _ := NewEnv("BM_SQL")
 	assert.NotNil(t, env)


### PR DESCRIPTION
Adding support for generic SQL. One detail, the default tests are run using lib/pq and the default are set to use Postgres as a local database.